### PR TITLE
Parallelize CPU-intensive transforming step

### DIFF
--- a/config/config.kafka.reference.hocon
+++ b/config/config.kafka.reference.hocon
@@ -72,9 +72,16 @@
     # - Events are uploaded to Databricks after exceeding this duration, even if the `maxBytes` size has not been reached
     "maxDelay": "1 second"
 
-    # - How many batches can we send simultaneously over the network to Databricks.
-    "uploadConcurrency":  1
+    # - Controls how many batches can we send simultaneously over the network to Databricks.
+    # -- E.g. If there are 4 available processors, and uploadParallelismFactor = 3.5, then we send up to 14 batches in parallel
+    # -- Adjusting this value can cause the app to use more or less of the available CPU.
+    "uploadParallelismFactor":  3
   }
+
+  # -- Controls how the app splits the workload into concurrent batches which can be run in parallel.
+  # -- E.g. If there are 4 available processors, and cpuParallelismFactor = 0.75, then we process 3 batches concurrently.
+  # -- Adjusting this value can cause the app to use more or less of the available CPU.
+  "cpuParallelismFactor": 0.75
 
   # Retry configuration for Databricks operation failures
   "retries": {

--- a/config/config.kinesis.reference.hocon
+++ b/config/config.kinesis.reference.hocon
@@ -106,9 +106,16 @@
     # - Events are uploaded to Databricks after exceeding this duration, even if the `maxBytes` size has not been reached
     "maxDelay": "1 second"
 
-    # - How many batches can we send simultaneously over the network to Databricks.
-    "uploadConcurrency":  1
+    # - Controls how many batches can we send simultaneously over the network to Databricks.
+    # -- E.g. If there are 4 available processors, and uploadParallelismFactor = 3.5, then we send up to 14 batches in parallel
+    # -- Adjusting this value can cause the app to use more or less of the available CPU.
+    "uploadParallelismFactor":  3
   }
+
+  # -- Controls how the app splits the workload into concurrent batches which can be run in parallel.
+  # -- E.g. If there are 4 available processors, and cpuParallelismFactor = 0.75, then we process 3 batches concurrently.
+  # -- Adjusting this value can cause the app to use more or less of the available CPU.
+  "cpuParallelismFactor": 0.75
 
   # Retry configuration for Databricks operation failures
   "retries": {

--- a/config/config.pubsub.reference.hocon
+++ b/config/config.pubsub.reference.hocon
@@ -78,9 +78,15 @@
     # - Events are uploaded to Databricks after exceeding this duration, even if the `maxBytes` size has not been reached
     "maxDelay": "1 second"
 
-    # - How many batches can we send simultaneously over the network to Databricks.
-    "uploadConcurrency":  1
+    # - Controls how many batches can we send simultaneously over the network to Databricks.
+    # -- E.g. If there are 4 available processors, and uploadParallelismFactor = 3.5, then we send up to 14 batches in parallel
+    # -- Adjusting this value can cause the app to use more or less of the available CPU.
   }
+
+  # -- Controls how the app splits the workload into concurrent batches which can be run in parallel.
+  # -- E.g. If there are 4 available processors, and cpuParallelismFactor = 0.75, then we process 3 batches concurrently.
+  # -- Adjusting this value can cause the app to use more or less of the available CPU.
+  "cpuParallelismFactor": 0.75
 
   # Retry configuration for Databricks operation failures
   "retries": {

--- a/modules/core/src/main/resources/reference.conf
+++ b/modules/core/src/main/resources/reference.conf
@@ -15,8 +15,10 @@
   "batching": {
     "maxBytes": 16000000
     "maxDelay": "1 second"
-    "uploadConcurrency":  3
+    "uploadParallelismFactor":  3
   }
+
+  "cpuParallelismFactor": 0.75
 
   "retries": {
     "setupErrors": {

--- a/modules/core/src/main/scala/com.snowplowanalytics.snowplow.databricks/Config.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.snowplow.databricks/Config.scala
@@ -32,6 +32,7 @@ case class Config[+Factory, +Source, +Sink](
   output: Config.Output[Sink],
   streams: Factory,
   batching: Config.Batching,
+  cpuParallelismFactor: BigDecimal,
   retries: Config.Retries,
   telemetry: Telemetry.Config,
   monitoring: Config.Monitoring,
@@ -67,7 +68,7 @@ object Config {
   case class Batching(
     maxBytes: Int,
     maxDelay: FiniteDuration,
-    uploadConcurrency: Int
+    uploadParallelismFactor: BigDecimal
   )
 
   case class Retries(

--- a/modules/core/src/test/scala/com.snowplowanalytics.snowplow.snowflake/MockEnvironment.scala
+++ b/modules/core/src/test/scala/com.snowplowanalytics.snowplow.snowflake/MockEnvironment.scala
@@ -77,9 +77,9 @@ object MockEnvironment {
     for {
       state <- Resource.eval(Ref[IO].of(Results(Vector.empty, Vector.empty)))
       batching = Config.Batching(
-                   maxBytes          = 16000000,
-                   maxDelay          = 10.seconds,
-                   uploadConcurrency = 1
+                   maxBytes                = 16000000,
+                   maxDelay                = 10.seconds,
+                   uploadParallelismFactor = 1
                  )
       serializer <- ParquetSerializer.resource[IO](batching, CompressionCodecName.SNAPPY)
     } yield {
@@ -94,6 +94,8 @@ object MockEnvironment {
         appHealth               = testAppHealth(state),
         serializer              = serializer,
         batching                = batching,
+        cpuParallelism          = 1,
+        uploadParallelism       = 1,
         badRowMaxSize           = 1000000,
         schemasToSkip           = List.empty,
         exitOnMissingIgluSchema = false,

--- a/modules/kafka/src/test/scala/com.snowplowanalytics.snowplow.databricks/KafkaConfigSpec.scala
+++ b/modules/kafka/src/test/scala/com.snowplowanalytics.snowplow.databricks/KafkaConfigSpec.scala
@@ -101,10 +101,11 @@ object KafkaConfigSpec {
     ),
     streams = (),
     batching = Config.Batching(
-      maxBytes          = 16000000,
-      maxDelay          = 1.second,
-      uploadConcurrency = 3
+      maxBytes                = 16000000,
+      maxDelay                = 1.second,
+      uploadParallelismFactor = 3
     ),
+    cpuParallelismFactor = 0.75,
     retries = Config.Retries(
       setupErrors     = Retrying.Config.ForSetup(delay = 30.seconds),
       transientErrors = Retrying.Config.ForTransient(delay = 1.second, attempts = 5)
@@ -174,10 +175,11 @@ object KafkaConfigSpec {
     ),
     streams = (),
     batching = Config.Batching(
-      maxBytes          = 16000000,
-      maxDelay          = 1.second,
-      uploadConcurrency = 1
+      maxBytes                = 16000000,
+      maxDelay                = 1.second,
+      uploadParallelismFactor = 3
     ),
+    cpuParallelismFactor = 0.75,
     retries = Config.Retries(
       setupErrors     = Retrying.Config.ForSetup(delay = 30.seconds),
       transientErrors = Retrying.Config.ForTransient(delay = 1.second, attempts = 5)

--- a/modules/kinesis/src/test/scala/com.snowplowanalytics.snowplow.databricks/KinesisConfigSpec.scala
+++ b/modules/kinesis/src/test/scala/com.snowplowanalytics.snowplow.databricks/KinesisConfigSpec.scala
@@ -98,10 +98,11 @@ object KinesisConfigSpec {
     ),
     streams = (),
     batching = Config.Batching(
-      maxBytes          = 16000000,
-      maxDelay          = 1.second,
-      uploadConcurrency = 3
+      maxBytes                = 16000000,
+      maxDelay                = 1.second,
+      uploadParallelismFactor = 3
     ),
+    cpuParallelismFactor = 0.75,
     retries = Config.Retries(
       setupErrors     = Retrying.Config.ForSetup(delay = 30.seconds),
       transientErrors = Retrying.Config.ForTransient(delay = 1.second, attempts = 5)
@@ -167,10 +168,11 @@ object KinesisConfigSpec {
     ),
     streams = (),
     batching = Config.Batching(
-      maxBytes          = 16000000,
-      maxDelay          = 1.second,
-      uploadConcurrency = 1
+      maxBytes                = 16000000,
+      maxDelay                = 1.second,
+      uploadParallelismFactor = 3
     ),
+    cpuParallelismFactor = 0.75,
     retries = Config.Retries(
       setupErrors     = Retrying.Config.ForSetup(delay = 30.seconds),
       transientErrors = Retrying.Config.ForTransient(delay = 1.second, attempts = 5)

--- a/modules/pubsub/src/test/scala/com.snowplowanalytics.snowplow.databricks/PubsubConfigSpec.scala
+++ b/modules/pubsub/src/test/scala/com.snowplowanalytics.snowplow.databricks/PubsubConfigSpec.scala
@@ -96,9 +96,9 @@ object PubsubConfigSpec {
     ),
     streams = PubsubFactoryConfig(PubsubUserAgent("Snowplow OSS", "databricks-loader"), None),
     batching = Config.Batching(
-      maxBytes          = 16000000,
-      maxDelay          = 1.second,
-      uploadConcurrency = 3
+      maxBytes                = 16000000,
+      maxDelay                = 1.second,
+      uploadParallelismFactor = 3
     ),
     retries = Config.Retries(
       setupErrors     = Retrying.Config.ForSetup(delay = 30.seconds),
@@ -114,6 +114,7 @@ object PubsubConfigSpec {
       moduleName      = None,
       moduleVersion   = None
     ),
+    cpuParallelismFactor = 0.75,
     monitoring = Config.Monitoring(
       metrics     = Config.Metrics(None),
       sentry      = None,
@@ -157,10 +158,11 @@ object PubsubConfigSpec {
     ),
     streams = PubsubFactoryConfig(PubsubUserAgent("Snowplow OSS", "databricks-loader"), None),
     batching = Config.Batching(
-      maxBytes          = 16000000,
-      maxDelay          = 1.second,
-      uploadConcurrency = 1
+      maxBytes                = 16000000,
+      maxDelay                = 1.second,
+      uploadParallelismFactor = 3
     ),
+    cpuParallelismFactor = 0.75,
     retries = Config.Retries(
       setupErrors     = Retrying.Config.ForSetup(delay = 30.seconds),
       transientErrors = Retrying.Config.ForTransient(delay = 1.second, attempts = 5)


### PR DESCRIPTION
Parallelism is configured by a new config parameter `cpuParallelismFactor`. The actual parallelism is chosen dynamically
based on the number of available CPU, so the default value should be appropriate for all sized VMs.

Also, `uploadConcurrency` is replaced with `uploadParallelismFactor` to choose upload parallelism dynamically based on the number of available CPU.