### PR TITLE
Fix to work with recovery columns

### DIFF
--- a/modules/core/src/main/scala/com.snowplowanalytics.snowplow.databricks/processing/Processing.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.snowplow.databricks/processing/Processing.scala
@@ -123,7 +123,7 @@ object Processing {
         nonAtomicFields <- possiblyExitOnClashingIgluSchemas(env, resolveTypesResult)
         _ <- possiblyExitOnMissingIgluSchema(env, nonAtomicFields)
         TransformUtils.TransformResult(moreBad, good) <- TransformUtils.transform[F](badProcessor, events, nonAtomicFields, env.devFeatures)
-        schema = ParquetSchema.forBatch(nonAtomicFields.fields.map(_.mergedField))
+        schema = ParquetSchema.forBatch(nonAtomicFields.fields.flatMap(tte => tte.mergedField :: tte.recoveries.map(_._2)))
       } yield Transformed(good, schema, parseFailures.prepend(moreBad), tokens, earliestTstamp)
     }
 


### PR DESCRIPTION
Refers to the snowplow feature in which invalid schema evolution is handled by creating a recovery column in the warehouse. Before this fix, the recovery feature was not working in the streaming databricks loader.